### PR TITLE
Link to the original hls.js project

### DIFF
--- a/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -90,7 +90,7 @@ DASH stands for Dynamic Adaptive Streaming over HTTP. It is supported via Media 
 
 HLS or HTTP Live Streaming is a protocol invented by Apple Inc and supported on iOS, Safari and the latest versions of Android browser / Chrome. HLS is also adaptive.
 
-HLS can also be decoded using JavaScript, which means we can support the latest versions of Firefox, Chrome and Safari. See this [HTTP Live Streaming JavaScript player](https://github.com/dailymotion/hls.js).
+HLS can also be decoded using JavaScript, which means we can support the latest versions of Firefox, Chrome and Safari. See this [HTTP Live Streaming JavaScript player](https://github.com/video-dev/hls.js).
 
 At the start of the streaming session, an [extended M3U (m3u8) playlist](https://en.wikipedia.org/wiki/M3U8#Extended_M3U_directives) is downloaded. This contains the metadata for the various sub-streams that are provided.
 


### PR DESCRIPTION
### Description

The link to the Javascript player used to point to a forked version of hls.js hosted by [dailymotion](https://github.com/dailymotion/hls.js). This patch changes the link to the one hosted by [video-dev](https://github.com/video-dev/hls.js)

### Motivation

The forked version of hls.js hasn't been updated in 5 years, whereas the original project is updated on a daily basis thank's to the work of @robwalch and many other contributors.
